### PR TITLE
Reference original Pull Request when updating master

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -46,7 +46,7 @@ class PullRequestPreview
       github.update_contents(
         viewer_sinatra_repo,
         'DATASOURCE',
-        'Update DATASOURCE',
+        "Update DATASOURCE\n\n##{pull_request_number}",
         datasource.sha,
         countries_json_url
       )


### PR DESCRIPTION
When we push to master before closing the Pull Request we want to
reference the Pull Request so that we've got a better audit trail.

Fixes https://github.com/everypolitician/everypolitician/issues/266
