### PR TITLE
Search for open AND closed pull requests

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -64,9 +64,11 @@ class PullRequestPreview
   end
 
   def existing_pull
-    @existing_pull ||= github.pull_requests(viewer_sinatra_repo).find do |pull|
-      pull.head.ref == branch_name
-    end
+    @existing_pull ||= github.pull_requests(
+      viewer_sinatra_repo,
+      head: [viewer_sinatra_repo.split('/').first, branch_name].join(':'),
+      state: :all
+    ).first
   end
 
   def existing_pull?


### PR DESCRIPTION
Sometimes pull requests are manually merged, either by accident or
sometimes on purpose for one reason or another.

Previously we would only search through the open viewer-sinatra pull
requests, if we didn't find one with the expected branch name then we
would try and create a new pull request. If a previous pull request had
used the branch name but was now merged creating the pull request would
fail because there would be no commits on the branch which weren't on
master.

To work around this we need to search through all pull requests to
ensure we find any existing pull requests that exist.

This commit also changes the way we search for the pull request by using
the `:head` option to the 'pull_requests' method. This is more efficient
than searching through an array of all pull requests.

Fixes https://github.com/everypolitician/everypolitician/issues/224
