### PR TITLE
Don't try to create pull requests when merging or closing

### DIFF
--- a/lib/viewer_sinatra.rb
+++ b/lib/viewer_sinatra.rb
@@ -28,8 +28,9 @@ class ViewerSinatra
   end
 
   def on_merged
+    return unless existing_pull_request?
+    viewer_sinatra_pull_request = existing_pull_request
     datasource = github.contents(viewer_sinatra_repo, path: 'DATASOURCE')
-    viewer_sinatra_pull_request = create_pull_request
     github.update_contents(
       viewer_sinatra_repo,
       'DATASOURCE',
@@ -51,7 +52,8 @@ class ViewerSinatra
   end
 
   def on_closed
-    viewer_sinatra_pull_request = create_pull_request
+    return unless existing_pull_request?
+    viewer_sinatra_pull_request = existing_pull_request
     message = 'The parallel Pull Request in everypolitician-data was closed ' \
       'with unmerged commits.'
     github.add_comment(viewer_sinatra_repo, viewer_sinatra_pull_request.number, message)

--- a/lib/viewer_sinatra.rb
+++ b/lib/viewer_sinatra.rb
@@ -85,21 +85,21 @@ class ViewerSinatra
     ].join("\n")
   end
 
-  def existing_pull
-    @existing_pull ||= github.pull_requests(
+  def existing_pull_request
+    @existing_pull_request ||= github.pull_requests(
       viewer_sinatra_repo,
       head: [viewer_sinatra_repo.split('/').first, branch_name].join(':'),
       state: :all
     ).first
   end
 
-  def existing_pull?
-    !existing_pull.nil?
+  def existing_pull_request?
+    !existing_pull_request.nil?
   end
 
   def create_pull_request
-    if existing_pull?
-      existing_pull
+    if existing_pull_request?
+      existing_pull_request
     else
       github.create_pull_request(
         viewer_sinatra_repo,


### PR DESCRIPTION
If an everypolitician-data pull request is being merged or closed we were previously trying to create a viewer-sinatra pull request if it didn't already exist. This doesn't make sense, since the original pull request is being closed or merge anyway. Instead just use the existing pull request if it's there.

Fixes #6 
